### PR TITLE
Fix ref seq FASTA concatenation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.1.1](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.1)] - 2022-08-31
+
+Patch release to fix issue when a user-specified sequences FASTA is provided and the FASTA is concatenated with the NCBI influenza sequences FASTA, but there is no new-line character at the end of the FASTA files. New line characters are added to the FASTA files to avoid incorrect concatenation.
+
 ## [[3.1.0](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.0)] - 2022-05-31
 
 The workflow's name has been changed from `nf-iav-illumina` to `nf-flu` and the official repo for `nf-flu` will be [CFIA-NCFAD/nf-flu](https://github.com/CFIA-NCFAD/nf-flu/) going forward.

--- a/docs/output.md
+++ b/docs/output.md
@@ -13,7 +13,7 @@ The directories listed below will be created in the results directory after the 
 - [Mismatch Report](#mismatch-report)
 - [Reference Sequences](#reference-sequences)
 - [Variant Calling](#variant-calling)
-- [H/N Subtyping](#h-n-subtyping)
+- [H/N Subtyping](#hn-subtyping)
 
 ### IRMA
 
@@ -56,9 +56,9 @@ The directories listed below will be created in the results directory after the 
 
 </details>
 
-IRMA output is described in the [official IRMA output documentation](https://wonder.cdc.gov/amd/flu/irma/output.html).
+[IRMA][] output is described in the [official IRMA output documentation](https://wonder.cdc.gov/amd/flu/irma/output.html).
 
-The primary output from IRMA are the consensus sequences for gene segments, which are used for H/N subtyping and performed blastn against influenza database to pull top match reference sequences for each segment of each sample.
+The primary output from [IRMA][] are the consensus sequences for gene segments, which are used for H/N subtyping and performed blastn against influenza database to pull top match reference sequences for each segment of each sample.
 
 ### BLAST analysis
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -78,7 +78,7 @@ The primary output from [IRMA][] are the consensus sequences for gene segments, 
 
 </details>
 
-[IRMA][] and final assembled gene segments are queried against the [NCBI Influenza DB][] and the reference database (if provided option `--ref_db`) using nucleotide [BLAST][] to determine the closest matching sequences in NCBI and the reference database for each segment of each sample for downstream analysis and to predict the H and N subtype of each sample if possible (i.e. if segments 4 (hemagglutinin) and/or 6 (neuraminidase) were assembled).
+Nucleotide [BLAST](https://blast.ncbi.nlm.nih.gov/Blast.cgi) (`blastn`) is used to query [IRMA][] assembled gene segment sequences against the [NCBI Influenza DB][] sequences (and optionally, against user-specified sequences (`--ref_db`) to predict the H and N subtype of each sample if possible (i.e. if segments 4 (hemagglutinin) and/or 6 (neuraminidase) were assembled) and to determine the closest matching reference sequence for each segment for reference mapped assembly.
 
 ### Coverage Plots
 
@@ -176,7 +176,7 @@ This sheet contains the H/N subtype prediction results for each sample along wit
 | Field | Description                                                                                                                                                                                                                                                                                               | Example |
 |-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | Sample | Sample name                                                                                                                                                                                                                                                                                               | ERR3338653 |
-| Subtype Prediction | H/N subtype prediction based on BLAST+ against the Influenza DB. If a type could not be assigned to either H or N segment or both, then the subtype prediction will be missing the H or N value or if both the H and N cannot be assigned then the subtype prediction will be null or an empty cell value | H1N1 |
+| Subtype Prediction | H/N subtype prediction based on [BLAST][]+ against the Influenza DB. If a type could not be assigned to either H or N segment or both, then the subtype prediction will be missing the H or N value or if both the H and N cannot be assigned then the subtype prediction will be null or an empty cell value | H1N1 |
 | H: top match accession | NCBI accession of top matching Influenza sequence for the H segment                                                                                                                                                                                                                                       | CY147779 |
 | H: type prediction | H subtype prediction number. Value is a number.                                                                                                                                                                                                                                                           | 1 |
 | H: top match virus name | Top matching sequence virus name                                                                                                                                                                                                                                                                          | Influenza A virus (A/Mexico/24036/2009(H1N1)) |
@@ -262,5 +262,4 @@ Below are shown the fields for the "3_H Segment Results" sheet. The fields are n
 [Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.
 
 [NCBI Influenza DB]: https://www.ncbi.nlm.nih.gov/genomes/FLU/Database/nph-select.cgi?go=database
-[BLAST]: https://blast.ncbi.nlm.nih.gov/Blast.cgi
 [IRMA]: https://wonder.cdc.gov/amd/flu/irma/

--- a/modules/local/misc.nf
+++ b/modules/local/misc.nf
@@ -40,23 +40,21 @@ process CAT_NANOPORE_FASTQ {
 process CAT_DB {
     tag "$fasta1 - $fasta2"
 
-    conda (params.enable_conda ? "conda-forge::pigz=2.6" : null)
-    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-2b04072095278721dc9a5772e61e406f399b6030:7c7abf911e92d7fb831611ffb965f3cf7fe2c01d-0"
-    }
+    executor 'local'
+    memory 100.MB
 
     input:
     path(fasta1)
     path(fasta2)
 
     output:
-    path("*.fasta"), emit: fasta
+    path("influenza_db.fasta"), emit: fasta
 
     script:
     """
-    cat $fasta1 $fasta2 > influenza_db.fasta
+    cp $fasta1 influenza_db.fasta
+    echo >> influenza_db.fasta
+    cat $fasta2 >> influenza_db.fasta
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -122,7 +122,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.1.0'
+  version         = '3.1.1'
   nextflowVersion = '>=21.10'
   mainScript      = 'main.nf'
 }

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -134,8 +134,8 @@ workflow NANOPORE {
   ch_input_ref_db = GUNZIP_NCBI_FLU_FASTA.out.fna
 
   if (params.ref_db){
-    ref_fasta_file = file(params.ref_db, type: 'file')
-    CHECK_REF_FASTA(ref_fasta_file)
+    Channel.fromPath(params.ref_db).set { ch_ref_fasta }
+    CHECK_REF_FASTA(ch_ref_fasta)
     ch_versions = ch_versions.mix(CHECK_REF_FASTA.out.versions)
     CAT_DB(GUNZIP_NCBI_FLU_FASTA.out.fna, CHECK_REF_FASTA.out.fasta)
     ch_input_ref_db = CAT_DB.out.fasta


### PR DESCRIPTION
This PR fixes an issue when a user-specified sequences FASTA is provided and the FASTA is concatenated with the NCBI influenza sequences FASTA, but there is no new-line character at the end of the FASTA files. New line characters are added to the FASTA files to avoid incorrect concatenation.

Bumps version to 3.1.1

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
