### PR TITLE
Revert params.ref_db to use file function for creating value Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [[3.1.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.2)] - 2022-09-01
+
+Patch release to fix issue when user reference sequences FASTA specified, but Channel from file is not treated as a value. Code has been reverted to use `file` Nextflow function.
+
 ## [[3.1.1](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.1)] - 2022-08-31
 
 Patch release to fix issue when a user-specified sequences FASTA is provided and the FASTA is concatenated with the NCBI influenza sequences FASTA, but there is no new-line character at the end of the FASTA files. New line characters are added to the FASTA files to avoid incorrect concatenation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [[3.1.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.2)] - 2022-09-01
 
 Patch release to fix issue when user reference sequences FASTA specified, but Channel from file is not treated as a value. Code has been reverted to use `file` Nextflow function.

--- a/nextflow.config
+++ b/nextflow.config
@@ -122,7 +122,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.1.1'
+  version         = '3.1.2'
   nextflowVersion = '>=21.10'
   mainScript      = 'main.nf'
 }

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -134,7 +134,7 @@ workflow NANOPORE {
   ch_input_ref_db = GUNZIP_NCBI_FLU_FASTA.out.fna
 
   if (params.ref_db){
-    Channel.fromPath(params.ref_db).set { ch_ref_fasta }
+    ch_ref_fasta = file(params.ref_db, type: 'file')
     CHECK_REF_FASTA(ch_ref_fasta)
     ch_versions = ch_versions.mix(CHECK_REF_FASTA.out.versions)
     CAT_DB(GUNZIP_NCBI_FLU_FASTA.out.fna, CHECK_REF_FASTA.out.fasta)


### PR DESCRIPTION
This PR reverts the `params.ref_db` to be initialized into a value Channel with the `file` Nextflow function.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Make sure your code lints (`nf-core lint .`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
