### PR TITLE
Fix issues 11,13,15 and update Clair3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.1.5](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.5)] - 2023-05-30
+
+### Added
+
+* `--use_mamba` to enable using [Mamba](https://github.com/mamba-org/mamba/) in place of Conda when using `-profile conda` for faster creation of Conda environments
+
+### Updates
+
+* Clair3: 0.1.10 -> 1.0.2
+
+### Fixes
+
+* user-specified Clair3 models not being found ([#11](https://github.com/CFIA-NCFAD/nf-flu/issues/11))
+* Conda profile not enabling Conda ([#15](https://github.com/CFIA-NCFAD/nf-flu/issues/15))
+* IRMA wanting too much `/tmp` space; IRMA's tmp dir will be output to the current working directory of the process job ([#13](https://github.com/CFIA-NCFAD/nf-flu/issues/13)) (Thanks @Codes1985 for reporting and solving this issue!)
+
 ## [[3.1.4](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.1.4)] - 2023-05-17
 
 This release addresses issue [#11](https://github.com/CFIA-NCFAD/nf-flu/issues/11) adding a new option `--clair3_user_variant_model <PATH TO CLAIR3 MODEL>` to allow user to provide a Clair3 model not included with Clair3, e.g. a [Rerio](https://github.com/nanoporetech/rerio) Clair3 model for r10 flowcells.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -318,6 +318,13 @@ Directory to keep pipeline Nextflow logs and reports.
 
 Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter.
 
+#### `--use_mamba`
+
+- Optional
+- Type: boolean
+
+Use Mamba in place of Conda for faster Conda env creation.
+
 #### `--singularity_pull_docker_container`
 
 - Optional

--- a/modules/local/clair3.nf
+++ b/modules/local/clair3.nf
@@ -5,15 +5,17 @@ process CLAIR3 {
   tag "$sample|$segment|$ref_id"
   label 'process_low'
 
-  conda (params.enable_conda ? 'bioconda::clair3==0.1.10' : null)
+  conda (params.enable_conda ? 'bioconda::clair3==1.0.2' : null)
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'hkubal/clair3:v0.1-r10'
+    container 'hkubal/clair3:v1.0.2'
   } else {
-    container 'hkubal/clair3:v0.1-r10'
+    container 'hkubal/clair3:v1.0.2'
   }
 
   input:
   tuple val(sample), val(segment), val(ref_id), path(ref_fasta), path(bam)
+  // optional model_path
+  path model_path 
 
   output:
   tuple val(sample), val(segment), val(ref_id), path(ref_fasta), path(vcf), emit: vcf
@@ -31,7 +33,7 @@ process CLAIR3 {
   """
   CLAIR_BIN_DIR=\$(dirname \$(which run_clair3.sh))
   if [[ "${params.clair3_user_variant_model}" != "" ]] ; then
-      MODEL_PATH=${params.clair3_user_variant_model}
+      MODEL_PATH=${model_path}
   else
       if [[ ${params.enable_conda} = true ]] ; then
           MODEL_PATH="\$CLAIR_BIN_DIR/${model_suffix}"

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -1,7 +1,3 @@
-// Import generic module functions
-include { getSoftwareName } from './functions'
-
-
 process IRMA {
   tag "$meta.id"
   label 'process_high'
@@ -16,28 +12,31 @@ process IRMA {
   input:
   tuple val(meta), path(reads)
   val (irma_module)
-  
+
   output:
   tuple val(meta), path("${meta.id}/"), emit: irma
   tuple val(meta), path("${meta.id}.irma.consensus.fasta"), optional: true, emit: consensus
   path "*.irma.log", emit: log
-  path "versions.yml" , emit: versions
+  path "versions.yml", emit: versions
 
   script:
-  def software = getSoftwareName(task.process)
-  irma_config = "DEL_TYPE=\"NNN\"\nALIGN_PROG=\"BLAT\""
-  irma_log    = "${meta.id}.irma.log"
+  def irma_config = "DEL_TYPE=\"NNN\"\nALIGN_PROG=\"BLAT\""
+  def irma_log    = "${meta.id}.irma.log"
   """
   touch irma_config.sh
   echo 'SINGLE_LOCAL_PROC=${task.cpus}' >> irma_config.sh
   echo 'DOUBLE_LOCAL_PROC=${(task.cpus / 2).toInteger()}' >> irma_config.sh
+  # default tmp in current working directory instead of defaulting to /tmp 
+  # which may be restricted in size on HPC clusters
+  echo 'ALLOW_TMP=1' >> irma_config.sh
+  echo 'TMP=\$PWD' >> irma_config.sh
   if [ ${params.keep_ref_deletions} ]; then
     echo 'DEL_TYPE="NNN"' >> irma_config.sh
     echo 'ALIGN_PROG="BLAT"' >> irma_config.sh
   fi
 
   IRMA $irma_module $reads $meta.id
-  
+
   if [ -d "${meta.id}/amended_consensus/" ]; then
     cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.irma.consensus.fasta
   fi

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,6 +60,7 @@ params {
   singularity_pull_docker_container = false
   show_hidden_params                = false
   schema_ignore_params              = 'modules,genomes'
+  use_mamba                         = false
 }
 
 includeConfig 'conf/base.config'
@@ -74,7 +75,8 @@ profiles {
   conda {
     params.enable_conda = true
     conda.createTimeout = "120 min"
-    //conda.useMamba = false
+    conda.enabled = true
+    conda.useMamba = params.use_mamba
   }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker {
@@ -123,7 +125,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.1.4'
+  version         = '3.1.5'
   nextflowVersion = '>=21.10'
   mainScript      = 'main.nf'
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -276,6 +276,13 @@
                     "hidden": true,
                     "fa_icon": "fas fa-bacon"
                 },
+                "use_mamba": {
+                    "type": "boolean",
+                    "description": "Use Mamba in place of Conda for faster Conda env creation.",
+                    "default": false,
+                    "hidden": true,
+                    "fa_icon": "fas fa-speedometer"
+                },
                 "singularity_pull_docker_container": {
                     "type": "boolean",
                     "description": "Instead of directly downloading Singularity images for use with Singularity, force the workflow to pull and convert Docker containers instead.",


### PR DESCRIPTION
This PR fixes issues #11 , #13  and #15. Workflow version bumped to 3.1.5.

### Added

* `--use_mamba` to enable using [Mamba](https://github.com/mamba-org/mamba/) in place of Conda when using `-profile conda` for faster creation of Conda environments

### Updates

* Clair3: 0.1.10 -> 1.0.2

### Fixes

* user-specified Clair3 models not being found ([#11](https://github.com/CFIA-NCFAD/nf-flu/issues/11))
* Conda profile not enabling Conda ([#15](https://github.com/CFIA-NCFAD/nf-flu/issues/15))
* IRMA wanting too much `/tmp` space; IRMA's tmp dir will be output to the current working directory of the process job ([#13](https://github.com/CFIA-NCFAD/nf-flu/issues/13)) (Thanks @Codes1985 for reporting and solving this issue!)

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
