### PR TITLE
Fix subtype report subtype prediction when user seqs provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.3](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.3)] - 2023-08-16
+
+This release fixes issues with subtype report generation script (`parse_influenza_blast_results.py`), primarily subtype predictions being `N/A` for samples where the top BLAST hits are user-specified sequences for the HA and NA segments.
+
+### Fixes
+
+* subtype prediction based off majority H/N prediction of all BLAST hits instead of just the top X matches (#40)
+* the top hit for H/N can also be a user-specified sequence without subtype information
+* top segment matches are now sorted by sample name, segment name and BLAST bitscore
+
+
 ## [[3.3.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.2)] - 2023-08-03
 
 This patch release fixes an IBV subtype/genotype parsing issue when generating subtyping report using the new metadata format introduced in 3.3.0 ([#32](https://github.com/CFIA-NCFAD/nf-flu/issues/32)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This release fixes issues with subtype report generation script (`parse_influenz
 * subtype prediction based off majority H/N prediction of all BLAST hits instead of just the top X matches (#40)
 * the top hit for H/N can also be a user-specified sequence without subtype information
 * top segment matches are now sorted by sample name, segment name and BLAST bitscore
+* output concatenated Nanopore FASTQ to `${outdir}/fastq` by default (#43)
+* Handle ambiguous bases in reference sequences by having Clair3 not convert those positions to N and Bcftools produce a warning instead of an error (#42)
 
 ## [[3.3.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.2)] - 2023-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This release fixes issues with subtype report generation script (`parse_influenz
 * the top hit for H/N can also be a user-specified sequence without subtype information
 * top segment matches are now sorted by sample name, segment name and BLAST bitscore
 
-
 ## [[3.3.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.2)] - 2023-08-03
 
 This patch release fixes an IBV subtype/genotype parsing issue when generating subtyping report using the new metadata format introduced in 3.3.0 ([#32](https://github.com/CFIA-NCFAD/nf-flu/issues/32)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This release fixes issues with subtype report generation script (`parse_influenz
 * output concatenated Nanopore FASTQ to `${outdir}/fastq` by default (#43)
 * Handle ambiguous bases in reference sequences by having Clair3 not convert those positions to N and Bcftools produce a warning instead of an error (#42)
 
+### Changes
+
+* subtyping report results are now ordered in the same order as the input `samplesheet.csv`, that is the order of the samples in the report is the same as the order of the samples in the `samplesheet.csv` file
+
 ## [[3.3.2](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.2)] - 2023-08-03
 
 This patch release fixes an IBV subtype/genotype parsing issue when generating subtyping report using the new metadata format introduced in 3.3.0 ([#32](https://github.com/CFIA-NCFAD/nf-flu/issues/32)).

--- a/conf/modules_nanopore.config
+++ b/conf/modules_nanopore.config
@@ -11,6 +11,17 @@ process {
     ]
   }
 
+  withName: 'CAT_NANOPORE_FASTQ' {
+    ext.args = ''
+    publishDir = [
+      [
+        path: { "${params.outdir}/fastq" },
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+      ]
+    ]
+  }
+
   withName: 'IRMA' {
     publishDir = [
       [

--- a/modules/local/bcftools.nf
+++ b/modules/local/bcftools.nf
@@ -70,6 +70,7 @@ process BCF_FILTER {
   bcftools_filt_vcf = "${prefix}.bcftools_filt.vcf"
   """
   bcftools norm \\
+    --check-ref w \\
     -Ov \\
     -m- \\
     -f $fasta \\

--- a/modules/local/clair3.nf
+++ b/modules/local/clair3.nf
@@ -54,6 +54,7 @@ process CLAIR3 {
       --output=${clair3_dir} \\
       --haploid_sensitive \\
       --enable_long_indel \\
+      --keep_iupac_bases \\
       --fast_mode \\
       --include_all_ctgs
 

--- a/modules/local/misc.nf
+++ b/modules/local/misc.nf
@@ -1,5 +1,3 @@
-include { getSoftwareName; fluPrefix } from './functions'
-
 process CAT_NANOPORE_FASTQ {
   tag "${meta.id}"
   label 'process_low'

--- a/modules/local/misc.nf
+++ b/modules/local/misc.nf
@@ -87,6 +87,3 @@ process CAT_CONSENSUS {
   END_VERSIONS
   """
 }
-
-
-

--- a/modules/local/subtyping_report.nf
+++ b/modules/local/subtyping_report.nf
@@ -25,6 +25,7 @@ process SUBTYPING_REPORT {
   input:
   path(genomeset)
   path(blastn_results)
+  path(samplesheet)
 
   output:
   path('nf-flu-subtyping-report.xlsx'), emit: report
@@ -38,6 +39,7 @@ process SUBTYPING_REPORT {
    --top ${params.max_top_blastn} \\
    --excel-report nf-flu-subtyping-report.xlsx \\
    --pident-threshold $params.pident_threshold \\
+   --samplesheet $samplesheet \\
    $blastn_results
 
   ln -s .command.log parse_influenza_blast_results.log

--- a/nextflow.config
+++ b/nextflow.config
@@ -151,7 +151,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.3.2'
+  version         = '3.3.3'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
   doi             = '10.5281/zenodo.7011213'

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -87,7 +87,11 @@ workflow ILLUMINA {
   ch_versions = ch_versions.mix(BLAST_BLASTN.out.versions.first().ifEmpty(null))
 
   ch_blast = BLAST_BLASTN.out.txt.collect({ it[1] })
-  SUBTYPING_REPORT(ZSTD_DECOMPRESS_CSV.out.file, ch_blast)
+  SUBTYPING_REPORT(
+    ZSTD_DECOMPRESS_CSV.out.file,
+    ch_blast,
+    CHECK_SAMPLE_SHEET.out
+  )
   ch_versions = ch_versions.mix(SUBTYPING_REPORT.out.versions)
 
   SOFTWARE_VERSIONS(ch_versions.unique().collectFile(name: 'collated_versions.yml'))

--- a/workflows/nanopore.nf
+++ b/workflows/nanopore.nf
@@ -161,7 +161,11 @@ workflow NANOPORE {
   //Generate suptype prediction report
   if (!params.skip_irma_subtyping_report){
     ch_blast_irma = BLAST_BLASTN_IRMA.out.txt.collect({ it[1] })
-    SUBTYPING_REPORT_IRMA_CONSENSUS(ZSTD_DECOMPRESS_CSV.out.file, ch_blast_irma)
+    SUBTYPING_REPORT_IRMA_CONSENSUS(
+      ZSTD_DECOMPRESS_CSV.out.file,
+      ch_blast_irma,
+      CHECK_SAMPLE_SHEET.out
+    )
   }
 
   // Prepare top ncbi accession id for each segment of each sample sample (id which has top bitscore)
@@ -244,7 +248,11 @@ workflow NANOPORE {
   ch_versions = ch_versions.mix(BLAST_BLASTN_CONSENSUS.out.versions)
 
   ch_blastn_consensus = BLAST_BLASTN_CONSENSUS.out.txt.collect({ it[1] })
-  SUBTYPING_REPORT_BCF_CONSENSUS(ZSTD_DECOMPRESS_CSV.out.file, ch_blastn_consensus)
+  SUBTYPING_REPORT_BCF_CONSENSUS(
+    ZSTD_DECOMPRESS_CSV.out.file, 
+    ch_blastn_consensus,
+    CHECK_SAMPLE_SHEET.out
+  )
   ch_versions = ch_versions.mix(SUBTYPING_REPORT_BCF_CONSENSUS.out.versions)
 
   if (params.ref_db){


### PR DESCRIPTION
This PR fixes issues with subtype report generation script (`parse_influenza_blast_results.py`), primarily subtype predictions being `N/A` for samples where the top BLAST hits are user-specified sequences for the HA and NA segments.

## Fixes

* subtype prediction based off majority H/N prediction of all BLAST hits instead of just the top X matches (#40)
* the top hit for H/N can also be a user-specified sequence without subtype information
* top segment matches are now sorted by sample name, segment name and BLAST bitscore
* output concatenated Nanopore FASTQ to `${outdir}/fastq` by default (#43)
* Handle ambiguous bases in reference sequences by having Clair3 not convert those positions to N and Bcftools produce a warning instead of an error (#42)

## Changes

* subtyping report results are now ordered in the same order as the input `samplesheet.csv`, that is the order of the samples in the report is the same as the order of the samples in the `samplesheet.csv` file

## TODO

- [X] order subtyping report results in the same order as samplesheet.csv

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
