### PR TITLE
Fix subtype report columns for "1_Subtype Predictions" sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.4](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.4)] - 2023-08-18
+
+### Fixes
+
+* Subtyping report summary sheet "1_Subtype Predictions" shows only N subtype results
+
 ## [[3.3.3](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.3)] - 2023-08-16
 
 This release fixes issues with subtype report generation script (`parse_influenza_blast_results.py`), primarily subtype predictions being `N/A` for samples where the top BLAST hits are user-specified sequences for the HA and NA segments.

--- a/bin/parse_influenza_blast_results.py
+++ b/bin/parse_influenza_blast_results.py
@@ -485,7 +485,7 @@ def report(
         df_all_blast_pandas.rename(
             columns=dict(BLAST_RESULTS_REPORT_COLUMNS)
         )
-        df_subtype_predictions = df_subtype_results[cols].rename(
+        df_subtype_predictions = df_subtype_results[SUBTYPE_RESULTS_SUMMARY_COLUMNS].rename(
             columns=SUBTYPE_RESULTS_SUMMARY_FINAL_NAMES
         )
         df_H = df_H.rename(columns=SUBTYPE_RESULTS_SUMMARY_FINAL_NAMES)

--- a/nextflow.config
+++ b/nextflow.config
@@ -151,7 +151,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.3.3'
+  version         = '3.3.4'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
   doi             = '10.5281/zenodo.7011213'


### PR DESCRIPTION
This PR fixes an issue with the subtyping report summary sheet "1_Subtype Predictions" showing only N subtype results.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [X] `CHANGELOG.md` is updated.
