### PR TITLE
Check IRMA amended_consensus fasta files exist before concatenation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,11 @@ jobs:
       - name: Fetch IBV test seq
         run: |
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/SRR24826962.sampled.fastq.gz > reads/SRR24826962.fastq.gz
+      - name: Fetch negative control seq data
+      - run: |
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc15.fastq.gz > reads/ntc-bc15.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc31.fastq.gz > reads/ntc-bc31.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc47.fastq.gz > reads/ntc-bc47.fastq.gz
       - name: Check IBV data
         run: |
           file reads/SRR24826962.fastq.gz
@@ -177,6 +182,9 @@ jobs:
           echo "ERR6359501,$(realpath run1)" | tee -a samplesheet.csv
           echo "ERR6359501,$(realpath run2)" | tee -a samplesheet.csv
           echo "SRR24826962,$(realpath reads/SRR24826962.fastq.gz)" | tee -a samplesheet.csv
+          echo "ntc-bc15,$(realpath reads/ntc-bc15.fastq.gz)" | tee -a samplesheet.csv
+          echo "ntc-bc31,$(realpath reads/ntc-bc31.fastq.gz)" | tee -a samplesheet.csv
+          echo "ntc-bc47,$(realpath reads/ntc-bc47.fastq.gz)" | tee -a samplesheet.csv
       - name: Cache subsampled influenza.fna
         uses: actions/cache@v3
         id: cache-influenza-fna
@@ -205,6 +213,13 @@ jobs:
             --input samplesheet.csv \
             --ncbi_influenza_fasta influenza-10k.fna.zst \
             --ncbi_influenza_metadata influenza.csv.zst
+      - name: Tree of results
+        run: tree -h results/
+      - name: Upload .nextflow.log
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: nextflow-log-nanopore-${{ matrix.nxf_ver }}
+          path: .nextflow.log
       - name: Upload pipeline_info/
         if: success()
         uses: actions/upload-artifact@v1.0.0
@@ -223,8 +238,3 @@ jobs:
         with:
           name: nanopore-test-results-multiqc-${{ matrix.nxf_ver }}
           path: results/MultiQC/multiqc_report.html
-      - name: Upload .nextflow.log
-        uses: actions/upload-artifact@v1.0.0
-        with:
-          name: nextflow-log-nanopore-${{ matrix.nxf_ver }}
-          path: .nextflow.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,39 +148,30 @@ jobs:
         with:
           path: reads/
           key: reads
-      - name: Fetch test data
+      - name: Fetch IAV and IBV test seq
         if: steps.cache-reads.outputs.cache-hit != 'true'
         run: |
-          mkdir reads
-          echo "Downloading ERR6359501 from EBI ENA"
-          curl -SLk --silent ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR635/001/ERR6359501/ERR6359501.fastq.gz > reads/ERR6359501.fastq.gz
-      - name: Fetch IBV test seq
-        run: |
+          mkdir -p reads/{run1,run2}
+          # IBV test data
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/SRR24826962.sampled.fastq.gz > reads/SRR24826962.fastq.gz
-      - name: Fetch negative control seq data
-        run: |
+          # IAV test data
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ERR6359501-10k.fastq.gz > reads/ERR6359501-10k.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run1-s11-ERR6359501.fastq.gz > reads/run1/s11-ERR6359501.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run1-s1-ERR6359501.fastq.gz > reads/run1/s1-ERR6359501.fastq.gz
+          # uncompressed FASTQ should work too
+          gunzip reads/run1/s1-ERR6359501.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run2-s22-ERR6359501.fastq.gz > reads/run2/s22-ERR6359501.fastq.gz
+          curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run2-s2-ERR6359501.fastq.gz > reads/run2/s2-ERR6359501.fastq.gz
+          # neg ctrl 
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc15.fastq.gz > reads/ntc-bc15.fastq.gz
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc31.fastq.gz > reads/ntc-bc31.fastq.gz
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc47.fastq.gz > reads/ntc-bc47.fastq.gz
-      - name: Check IBV data
-        run: |
-          file reads/SRR24826962.fastq.gz
-          md5sum reads/SRR24826962.fastq.gz
-          sha256sum reads/SRR24826962.fastq.gz
       - name: Prepare samplesheet.csv
         run: |
-          echo "Subsample reads from ERR6359501.fastq.gz with seqtk to mock different runs and ways of specifying input"
-          mkdir run1
-          seqtk sample -s 1 reads/ERR6359501.fastq.gz 1000 > run1/s1.fq
-          seqtk sample -s 11 reads/ERR6359501.fastq.gz 1000 | gzip -ck > run1/s11.fastq.gz
-          mkdir run2
-          seqtk sample -s 2 reads/ERR6359501.fastq.gz 1000 > run2/s2.fastq
-          seqtk sample -s 2 reads/ERR6359501.fastq.gz 1000 | gzip -ck > run2/s2.fq.gz
-          seqtk sample -s 123 reads/ERR6359501.fastq.gz 10000 > reads/ERR6359501-10k.fastq
           echo "sample,reads" | tee -a samplesheet.csv
-          echo "ERR6359501-10k,$(realpath reads/ERR6359501-10k.fastq)" | tee -a samplesheet.csv
-          echo "ERR6359501,$(realpath run1)" | tee -a samplesheet.csv
-          echo "ERR6359501,$(realpath run2)" | tee -a samplesheet.csv
+          echo "ERR6359501-10k,$(realpath reads/ERR6359501-10k.fastq.gz)" | tee -a samplesheet.csv
+          echo "ERR6359501,$(realpath reads/run1)" | tee -a samplesheet.csv
+          echo "ERR6359501,$(realpath reads/run2)" | tee -a samplesheet.csv
           echo "SRR24826962,$(realpath reads/SRR24826962.fastq.gz)" | tee -a samplesheet.csv
           echo "ntc-bc15,$(realpath reads/ntc-bc15.fastq.gz)" | tee -a samplesheet.csv
           echo "ntc-bc31,$(realpath reads/ntc-bc31.fastq.gz)" | tee -a samplesheet.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/SRR24826962.sampled.fastq.gz > reads/SRR24826962.fastq.gz
       - name: Fetch negative control seq data
-      - run: |
+        run: |
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc15.fastq.gz > reads/ntc-bc15.fastq.gz
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc31.fastq.gz > reads/ntc-bc31.fastq.gz
           curl -SLk --silent https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc47.fastq.gz > reads/ntc-bc47.fastq.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.5](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.5)] - 2023-09-15
+
+### Fixes
+
+* handling of empty IRMA `amended_consensus/` when running a negative control or blank sequence (#47)
+
 ## [[3.3.4](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.4)] - 2023-08-18
 
 ### Fixes

--- a/bin/parse_influenza_blast_results.py
+++ b/bin/parse_influenza_blast_results.py
@@ -482,7 +482,7 @@ def report(
         df_all_blast_pandas["sample_segment"] = df_all_blast_pandas["sample_segment"]. \
             apply(lambda x: SEGMENT_NAMES[int(x)])
         # Rename columns to more human-readable names
-        df_all_blast_pandas.rename(
+        df_all_blast_pandas = df_all_blast_pandas.rename(
             columns=dict(BLAST_RESULTS_REPORT_COLUMNS)
         )
         df_subtype_predictions = df_subtype_results[SUBTYPE_RESULTS_SUMMARY_COLUMNS].rename(

--- a/docs/output.md
+++ b/docs/output.md
@@ -66,19 +66,19 @@ The primary output from [IRMA][] are the consensus sequences for gene segments, 
 <summary>Output files</summary>
 
 - `blast/ncbi/blast_db/`
-  - Nucleotide BLAST database of [NCBI Influenza DB][] and reference database (if provided option `--ref_db`): `influenza_db.*`
+  - Nucleotide [BLAST] database of [NCBI Influenza DB][] and reference database (if provided option `--ref_db`): `influenza_db.*`
 - `blast/ref_db/blast_db/`
-  - Nucleotide BLAST database of the reference database (if provided option `--ref_db`) ref_fasta.fixed.*`
+  - Nucleotide [BLAST] database of the reference database (if provided option `--ref_db`) ref_fasta.fixed.*`
 - `blast/blastn/irma`
-  - Nucleotide BLAST tabular output files (`-outfmt "6 qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen slen qcovs stitle"`) of sample IRMA assembled gene segments against the [NCBI Influenza DB][] and the reference database (if provided option `--ref_db`)
+  - Nucleotide [BLAST] tabular output files (`-outfmt "6 qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen slen qcovs stitle"`) of sample IRMA assembled gene segments against the [NCBI Influenza DB][] and the reference database (if provided option `--ref_db`)
 - `blast/blastn/consensus`
-  - Nucleotide BLAST tabular output files (`-outfmt "6 qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen slen qcovs stitle"`) of sample final consensus assembled gene segments against the [NCBI Influenza DB][] and the reference database (if provided option `--ref_db`)
+  - Nucleotide [BLAST] tabular output files (`-outfmt "6 qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen slen qcovs stitle"`) of sample final consensus assembled gene segments against the [NCBI Influenza DB][] and the reference database (if provided option `--ref_db`)
 - `blast/blastn/against_ref_db`
   - Nucleotide BLAST tabular output files (`-outfmt "6 qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen slen qcovs stitle"`) of sample final consensus assembled gene segments against the reference database only (if provided option `--ref_db`)
 
 </details>
 
-Nucleotide [BLAST](https://blast.ncbi.nlm.nih.gov/Blast.cgi) (`blastn`) is used to query [IRMA][] assembled gene segment sequences against [Influenza sequences from NCBI](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNucleotide/) (and optionally, against user-specified sequences (`--ref_db`) to predict the H and N subtype of each sample if possible (i.e. if segments 4 (hemagglutinin) and/or 6 (neuraminidase) were assembled) and to determine the closest matching reference sequence for each segment for reference mapped assembly.
+Nucleotide [BLAST][] (`blastn`) is used to query [IRMA][] assembled gene segment sequences against [Influenza sequences from NCBI](https://ftp.ncbi.nlm.nih.gov/genomes/Viruses/AllNucleotide/) (and optionally, against user-specified sequences (`--ref_db`) to predict the H and N subtype of each sample if possible (i.e. if segments 4 (hemagglutinin) and/or 6 (neuraminidase) were assembled) and to determine the closest matching reference sequence for each segment for reference mapped assembly.
 
 ### Coverage Plots
 

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -37,7 +37,7 @@ process IRMA {
 
   IRMA $irma_module $reads $meta.id
 
-  if [ -d "${meta.id}/amended_consensus/" ]; then
+  if compgen -G "${meta.id}/amended_consensus/*.fa" > /dev/null; then
     cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.irma.consensus.fasta
   fi
   ln -s .command.log $irma_log

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -37,7 +37,7 @@ process IRMA {
 
   IRMA $irma_module $reads $meta.id
 
-  if ls "${meta.id}/amended_consensus/*.fa" > /dev/null 2>&1; then
+  if ls ${meta.id}/amended_consensus/*.fa > /dev/null 2>&1; then
     cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.irma.consensus.fasta
   fi
   ln -s .command.log $irma_log

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -37,7 +37,7 @@ process IRMA {
 
   IRMA $irma_module $reads $meta.id
 
-  if compgen -G "${meta.id}/amended_consensus/*.fa" > /dev/null; then
+  if ls "${meta.id}/amended_consensus/*.fa" > /dev/null 2>&1; then
     cat ${meta.id}/amended_consensus/*.fa > ${meta.id}.irma.consensus.fasta
   fi
   ln -s .command.log $irma_log

--- a/nextflow.config
+++ b/nextflow.config
@@ -151,7 +151,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.3.4'
+  version         = '3.3.5'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
   doi             = '10.5281/zenodo.7011213'


### PR DESCRIPTION
This PR should fix issue #47. The concatenated consensus FASTA is optional so the pipeline should proceed without it being generated, but sometimes the `amended_consensus/` directory is created with no `*.fa` files so the check fails.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
  - [X] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [X] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [X] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
