### PR TITLE
Fix #54 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * docs updated to show proper profile to run test profiles for Illumina and Nanopore locally (#52)
 * `test_nanopore` profile has been updated to run locally with [the test samplesheet.csv updated with URLs to FASTQ files at CFIA-NCFAD/nf-test-datasets](https://github.com/CFIA-NCFAD/nf-test-datasets/blob/nf-flu/samplesheet/samplesheet_test_nanopore_influenza.csv)
+* read samplesheet CSV in `parse_influenza_blast_results.py` with all columns read as string rather than inferred (#54)
 
 ## [[3.3.5](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.5)] - 2023-09-15
 

--- a/bin/parse_influenza_blast_results.py
+++ b/bin/parse_influenza_blast_results.py
@@ -399,7 +399,8 @@ def report(
     if samplesheet:
         samplesheet_path = Path(samplesheet)
         if samplesheet_path.resolve().exists():
-            ordered_samples = pl.read_csv(samplesheet_path)['sample'].to_list()
+            # force reading of samplesheet.csv columns as string data type
+            ordered_samples = pl.read_csv(samplesheet_path, dtypes=[pl.Utf8, pl.Utf8])['sample'].to_list()
             logging.info(f"Using samplesheet to order samples: {ordered_samples}")
 
     logging.info(f'Parsing Influenza metadata file "{flu_metadata}"')


### PR DESCRIPTION
This PR fixes #54:

* read samplesheet CSV in `parse_influenza_blast_results.py` with all columns read as string rather than inferred

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
