### PR TITLE
Update software to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['22.10.1', '23.04.1']
+        nxf_ver: ['22.10.1', '24.04.2']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache Nextflow binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-nextflow
         with:
           path: /usr/local/bin/nextflow
@@ -49,7 +49,7 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
       - name: Cache seqtk binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-seqtk
         with:
           path: /usr/local/bin/seqtk
@@ -63,7 +63,7 @@ jobs:
           make install
           which seqtk
       - name: Cache subsampled influenza.fna
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-influenza-fna
         with:
           path: influenza-10k.fna.zst
@@ -73,7 +73,7 @@ jobs:
         run: |
           curl --silent -SLk ${FASTA_ZST_URL} | zstdcat | seqtk sample -s 789 - 10000 | zstd -ck > influenza-10k.fna.zst
       - name: Cache influenza.csv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-influenza-csv
         with:
           path: influenza.csv.zst
@@ -90,12 +90,12 @@ jobs:
             --ncbi_influenza_metadata influenza.csv.zst
       - name: Upload Artifact
         if: success()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: illumina-test-results-${{ matrix.nxf_ver }}
           path: results/pipeline_info
       - name: Upload .nextflow.log
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: nextflow-log-illumina-${{ matrix.nxf_ver }}
           path: .nextflow.log
@@ -111,12 +111,12 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['22.10.1', '23.04.1']
+        nxf_ver: ['22.10.1', '24.04.2']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache Nextflow binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-nextflow
         with:
           path: /usr/local/bin/nextflow
@@ -129,7 +129,7 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
       - name: Cache seqtk binary
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-seqtk
         with:
           path: /usr/local/bin/seqtk
@@ -143,7 +143,7 @@ jobs:
           make install
           which seqtk
       - name: Cache test sample reads
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-reads
         with:
           path: reads/
@@ -177,7 +177,7 @@ jobs:
           echo "ntc-bc31,$(realpath reads/ntc-bc31.fastq.gz)" | tee -a samplesheet.csv
           echo "ntc-bc47,$(realpath reads/ntc-bc47.fastq.gz)" | tee -a samplesheet.csv
       - name: Cache subsampled influenza.fna
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-influenza-fna
         with:
           path: influenza-10k.fna.zst
@@ -187,7 +187,7 @@ jobs:
         run: |
           curl --silent -SLk ${FASTA_ZST_URL} | zstdcat | seqtk sample -s 789 - 10000 | zstd -ck > influenza-10k.fna.zst
       - name: Cache influenza.csv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-influenza-csv
         with:
           path: influenza.csv.zst
@@ -207,25 +207,25 @@ jobs:
       - name: Tree of results
         run: tree -h results/
       - name: Upload .nextflow.log
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: nextflow-log-nanopore-${{ matrix.nxf_ver }}
           path: .nextflow.log
       - name: Upload pipeline_info/
         if: success()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: nanopore-test-results-pipline_info-${{ matrix.nxf_ver }}
           path: results/pipeline_info
       - name: Upload nf-flu-subtyping-report.xlsx
         if: success()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: nanopore-test-results-subtyping-report-${{ matrix.nxf_ver }}
           path: results/nf-flu-subtyping-report.xlsx
       - name: Upload multiqc_report.html
         if: success()
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: nanopore-test-results-multiqc-${{ matrix.nxf_ver }}
           path: results/MultiQC/multiqc_report.html

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,10 +11,8 @@ jobs:
   Markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '18'
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint
@@ -49,10 +47,8 @@ jobs:
   YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '18'
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Install yaml-lint
         run: npm install -g yaml-lint
       - name: Run yaml-lint

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,38 +43,3 @@ jobs:
             Thanks again for your contribution!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: false
-
-  YAML:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - name: Install yaml-lint
-        run: npm install -g yaml-lint
-      - name: Run yaml-lint
-        run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml" -o -name "*.yaml")
-
-      # If the above check failed, post a comment on the PR explaining the failure
-      - name: Post PR comment
-        if: failure()
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            ## YAML linting is failing
-
-            To keep the code consistent with lots of contributors, we run automated code consistency checks.
-            To fix this CI test, please run:
-
-            * Install `yaml-lint`
-                * [Install `npm`](https://www.npmjs.com/get-npm) then [install `yaml-lint`](https://www.npmjs.com/package/yaml-lint) (`npm install -g yaml-lint`)
-            * Fix the markdown errors
-                * Run the test locally: `yamllint $(find . -type f -name "*.yml" -o -name "*.yaml")`
-                * Fix any reported errors in your YAML files
-
-            Once you push these changes the test should pass, and you can hide this comment :+1:
-
-            We highly recommend setting up yaml-lint in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
-
-            Thanks again for your contribution!
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Long overdue software updates release.
 * multiqc: `1.12` -> `1.21`
 * seqtk: `1.3` -> `1.4`
 
+### Changes
+
+* dev: update GitHub Actions versions for CI and linting workflows
+
 ## [[3.3.8](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.8)] - 2024-02-16
 
 This bugfix patch release fixes an issue where a large number of ambiguous bases in the IRMA consensus can hinder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.9](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.9)] - 2024-05-30
+
+Long overdue software updates release.
+
+### Software Updates
+
+* bcftools: `1.15.1` -> `1.20`
+* blast: `2.14.0` -> `2.15.0`
+* clair3: `1.0.5` -> `1.0.9`
+* minimap2: `2.24` -> `2.28`
+* mosdepth: `0.3.3` -> `0.3.8`
+* multiqc: `1.12` -> `1.21`
+* seqtk: `1.3` -> `1.4`
+
 ## [[3.3.8](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.8)] - 2024-02-16
 
 This bugfix patch release fixes an issue where a large number of ambiguous bases in the IRMA consensus can hinder

--- a/modules/local/bcftools.nf
+++ b/modules/local/bcftools.nf
@@ -5,11 +5,11 @@ process BCF_CONSENSUS {
   tag "$sample|$segment|$ref_id"
   label 'process_medium'
 
-  conda 'bioconda::bcftools=1.15.1 conda-forge::gsl=2.7'
+  conda 'bioconda::bcftools=1.20 conda-forge::gsl=2.7'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/bcftools:1.15.1--h0ea216a_0'
+    container 'https://depot.galaxyproject.org/singularity/bcftools:1.20--h8b25389_0'
   } else {
-    container 'quay.io/biocontainers/bcftools:1.15.1--h0ea216a_0'
+    container 'quay.io/biocontainers/bcftools:1.20--h8b25389_0'
   }
 
   input:

--- a/modules/local/blast_makeblastdb.nf
+++ b/modules/local/blast_makeblastdb.nf
@@ -3,11 +3,11 @@ process BLAST_MAKEBLASTDB {
   tag "$fasta"
   label 'process_low'
 
-  conda 'bioconda::blast=2.14.0'
+  conda 'bioconda::blast=2.15.0'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/blast:2.14.0--h7d5a4b4_1'
+    container 'https://depot.galaxyproject.org/singularity/blast:2.15.0--pl5321h6f7f691_1'
   } else {
-    container 'quay.io/biocontainers/blast:2.14.0--h7d5a4b4_1'
+    container 'quay.io/biocontainers/blast:2.15.0--pl5321h6f7f691_1'
   }
 
   input:

--- a/modules/local/blastn.nf
+++ b/modules/local/blastn.nf
@@ -2,11 +2,11 @@ process BLAST_BLASTN {
   tag "$meta.id"
   label 'process_high'
 
-  conda 'bioconda::blast=2.14.0'
+  conda 'bioconda::blast=2.15.0'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/blast:2.14.0--h7d5a4b4_1'
+    container 'https://depot.galaxyproject.org/singularity/blast:2.15.0--pl5321h6f7f691_1'
   } else {
-    container 'quay.io/biocontainers/blast:2.14.0--h7d5a4b4_1'
+    container 'quay.io/biocontainers/blast:2.15.0--pl5321h6f7f691_1'
   }
 
   input:

--- a/modules/local/clair3.nf
+++ b/modules/local/clair3.nf
@@ -5,12 +5,12 @@ process CLAIR3 {
   tag "$sample|$segment|$ref_id"
   label 'process_low'
 
-  conda 'bioconda::clair3==1.0.5'
+  conda 'bioconda::clair3==1.0.9'
   // use official images to avoid issues with full alignment failing. See issues:
   // https://github.com/HKU-BAL/Clair3/issues/98
   // https://github.com/HKU-BAL/Clair3/issues/181
   // Biocontainers image fails for some reason.
-  container 'hkubal/clair3:v1.0.5'
+  container 'hkubal/clair3:v1.0.9'
 
   input:
   tuple val(sample), val(segment), val(ref_id), path(ref_fasta), path(bam)

--- a/modules/local/minimap2.nf
+++ b/modules/local/minimap2.nf
@@ -4,11 +4,11 @@ process MINIMAP2 {
   tag "$sample|$segment|$ref_id"
   label 'process_low'
 
-  conda 'bioconda::minimap2=2.24 bioconda::samtools=1.15'
+  conda 'bioconda::minimap2=2.28 bioconda::samtools=1.20'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0'
+    container 'https://depot.galaxyproject.org/singularity/minimap2:2.28--he4a0461_1'
   } else {
-    container 'quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0'
+    container 'quay.io/biocontainers/minimap2:2.28--he4a0461_1'
   }
 
 

--- a/modules/local/minimap2.nf
+++ b/modules/local/minimap2.nf
@@ -6,11 +6,10 @@ process MINIMAP2 {
 
   conda 'bioconda::minimap2=2.28 bioconda::samtools=1.20'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/minimap2:2.28--he4a0461_1'
+    container 'https://depot.galaxyproject.org/singularity/mulled-v2-058de387f9917a7a63953f496cdd203bca83b790:86215829f86df9201683956877a19d025261ff66-0'
   } else {
-    container 'quay.io/biocontainers/minimap2:2.28--he4a0461_1'
+    container 'quay.io/biocontainers/mulled-v2-058de387f9917a7a63953f496cdd203bca83b790:86215829f86df9201683956877a19d025261ff66-0'
   }
-
 
   input:
   tuple val(sample), val(segment), val(ref_id), path(ref_fasta), path(reads)

--- a/modules/local/mosdepth.nf
+++ b/modules/local/mosdepth.nf
@@ -4,12 +4,13 @@ process MOSDEPTH_GENOME {
   tag "$sample|$segment|$ref_id"
   label 'process_low'
 
-  conda 'bioconda::mosdepth=0.3.3'
+  conda 'bioconda::mosdepth=0.3.8'
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-      container "https://depot.galaxyproject.org/singularity/mosdepth:0.3.3--h37c5b7d_2"
+    container 'https://depot.galaxyproject.org/singularity/mosdepth:0.3.8--hd299d5a_0'
   } else {
-      container "quay.io/biocontainers/mosdepth:0.3.3--h01d7912_0"
+    container 'quay.io/biocontainers/mosdepth:0.3.8--hd299d5a_0'
   }
+
   input:
   tuple val(sample), val(segment), val(ref_id), path(fasta), path(bam_bai)
 

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -1,11 +1,11 @@
 process MULTIQC {
   label 'process_low'
 
-  conda "bioconda::multiqc=1.12"
+  conda "bioconda::multiqc=1.21"
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0'
+    container 'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0'
   } else {
-    container 'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0'
+    container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
   }
 
   input:

--- a/modules/local/seqtk_seq.nf
+++ b/modules/local/seqtk_seq.nf
@@ -5,11 +5,11 @@ process SEQTK_SEQ{
   tag "$sample|$segment|$ref_id"
   // use default process resources
 
-  conda "bioconda::seqtk=1.3"
+  conda "bioconda::seqtk=1.4"
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/seqtk:1.3--h5bf99c6_3'
+    container 'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_2'
   } else {
-    container 'quay.io/biocontainers/seqtk:1.3--h5bf99c6_3'
+    container 'quay.io/biocontainers/seqtk:1.4--he4a0461_2'
   }
 
   input:

--- a/modules/local/zstd_decompress.nf
+++ b/modules/local/zstd_decompress.nf
@@ -2,11 +2,7 @@ process ZSTD_DECOMPRESS {
 
   conda 'conda-forge::zstd=1.5.2'
   // TODO: using clair3 container here for zstd and since it might be used if running the Nanopore workflow, but should move to multi-package-container with just zstd and maybe curl to combine data fetch functionality
-  if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/clair3:1.0.3--py39h8492097_0'
-  } else {
-    container 'quay.io/biocontainers/clair3:1.0.3--py39h8492097_0'
-  }
+  container 'hkubal/clair3:v1.0.9'
 
   input:
   path(zstd_file, stageAs: "input*/*")

--- a/nextflow.config
+++ b/nextflow.config
@@ -151,7 +151,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.3.8'
+  version         = '3.3.9'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
   doi             = '10.5281/zenodo.7011213'


### PR DESCRIPTION
## Software Updates

- bcftools: `1.15.1` -> `1.20`
- blast: `2.14.0` -> `2.15.0`
- clair3: `1.0.5` -> `1.0.9`
- minimap2: `2.24` -> `2.28`
- mosdepth: `0.3.3` -> `0.3.8`
- multiqc: `1.12` -> `1.21`
- seqtk: `1.3` -> `1.4`

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - ensure that you've added the version info to a `versions.yml` and added it to the `ch_versions` channel in the workflow you added the tool to.
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [ ] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
