### PR TITLE
Fix MultiQC report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.10](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.10)] - 2024-05-31
+
+Fix MultiQC report generation due to module filter paths not working like in v1.12.
+
+### Software Updates
+
+* multiqc: `1.21` -> `1.22.1`
+
+### Changes
+
+* test: add `tests/run-nanopore-test.sh` to conveniently run Nanopore test locally
+
 ## [[3.3.9](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.3.9)] - 2024-05-30
 
 Long overdue software updates release.

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -20,20 +20,14 @@ module_order:
         name: 'Samtools (Minimap2)'
         anchor: 'samtools_minimap2'
         info: 'This section of the report shows Samtools counts/statistics after mapping with Minimap2.'
-        path_filters:
-            - './samtools/*'
     - mosdepth:
         name: 'Mosdepth (Minimap2)'
         anchor: 'mosdepth_minimap2'
         info: 'This section of the report shows Mosdepth calculated depth statistics after mapping with Minimap2'
-        path_filters:
-            - './mosdepth/*'
     - bcftools:
         name: 'Bcftools Stats'
         anchor: 'bcftools'
         info: 'This section of the report shows Bcftools calculated statistics after variant calling using Clair3/Medaka and filter frameshift'
-        path_filters:
-            - './bcftools/*'
 
 extra_fn_clean_exts:
     - type: remove

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -4,9 +4,9 @@ report_comment: >
     analysis pipeline. For information about how to interpret these results, please see the
     <a href="https://github.com/CFIA-NCFAD/nf-flu" target="_blank">documentation</a>.
 report_section_order:
-    software_versions:
+    CFIA-NCFAD-nf-flu-summary-module:
         order: -1000
-    CFIA-NCFAD-nf-flu-summary:
+    software_versions-module:
         order: -1001
 
 read_count_multiplier: 1.0
@@ -14,6 +14,7 @@ read_count_prefix: ''
 read_count_desc: ''
 
 export_plots: true
+disable_version_detection: true
 
 module_order:
     - samtools:
@@ -48,32 +49,21 @@ mosdepth_config:
         - 30
         - 10000
 
-run_modules:
-    - custom_content
-    - samtools
-    - mosdepth
-    - bcftools
-
-sp:
-    mosdepth/global_dist:
-        fn: '*.global.dist.txt'
-
 table_columns_visible:
-    'Samtools (Minimap2)':
+    'Samtools (Minimap2): stats':
         flagstat_total: false
         mapped_passed: false
         error_rate: false
         'non-primary_alignments': false
-    'Bcftools Stats':
+    'Bcftools Stats: Stats':
         number_of_MNPs: true
 
-
 table_columns_placement:
-    'Samtools (Minimap2)':
+    'Samtools (Minimap2): stats':
         reads_mapped: 1010
         raw_total_sequences: 1020
         reads_mapped_percent: 1030
-    'Bcftools Stats':
+    'Bcftools Stats: Stats':
         number_of_records: 1060
         number_of_SNPs: 1070
         number_of_MNPs: 1080

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -1,11 +1,11 @@
 process MULTIQC {
   label 'process_low'
 
-  conda "bioconda::multiqc=1.21"
+  conda "bioconda::multiqc=1.22.1"
   if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-    container 'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0'
+    container 'https://depot.galaxyproject.org/singularity/multiqc:1.22.1--pyhdfd78af_0'
   } else {
-    container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
+    container 'quay.io/biocontainers/multiqc:1.22.1--pyhdfd78af_0'
   }
 
   input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -151,7 +151,7 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.3.9'
+  version         = '3.3.10'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
   doi             = '10.5281/zenodo.7011213'

--- a/tests/run-nanopore-test.sh
+++ b/tests/run-nanopore-test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -euo pipefail
+
+error_handler() {
+    echo -e "\n\033[1;31mError on line $1\033[0m"
+    # Perform any cleanup or logging here
+}
+
+cleanup() {
+    echo "Cleaning up before exiting..."
+    # Cleanup commands go here
+}
+
+handle_interrupt() {
+    echo -e "\n\033[1;31mERROR:\033[1m Script interrupted...\033[0m"
+    cleanup
+    exit 1
+}
+
+# Trap ERR signal to handle errors
+trap 'error_handler $LINENO' ERR
+
+# Trap EXIT signal to perform cleanup
+trap cleanup EXIT
+
+# Trap SIGINT and SIGTERM to handle interruptions
+trap handle_interrupt SIGINT SIGTERM
+
+
+error() {
+  echo -e "$(date -Is)  \033[1;31mERROR: \033[0m\033[1m$1\033[0m"
+}
+
+info() {
+  echo -e "$(date -Is)  \033[1;32mINFO: \033[0m\033[1m$1\033[0m"
+}
+
+
+WORKFLOW_PATH="CFIA-NCFAD/nf-flu"
+CPU=$(nproc)
+MEMORY="8 GB"
+
+print_help() {
+    echo "Usage: $0 [-w WORKFLOW_PATH] [-m MEMORY] [-c CPU]"
+    echo
+    echo "Options:"
+    echo "  -w WORKFLOW_PATH    Path to the Nextflow workflow (default: ${WORKFLOW_PATH})"
+    echo "  -m MEMORY           Memory allocation for the Nextflow run (default: ${MEMORY})"
+    echo "  -c CPU              CPU allocation for the Nextflow run (default: ${CPU})"
+    echo "  -h                  Display this help message"
+}
+
+while getopts "w:m:c:h" opt; do
+    case $opt in
+        w) WORKFLOW_PATH=$OPTARG ;;
+        m) MEMORY=$OPTARG ;;
+        c) CPU=$OPTARG ;;
+        h) print_help; exit 0 ;;
+        \?) error "Invalid option: -$OPTARG" >&2; print_help; exit 1 ;;
+        :) error "Option -$OPTARG requires an argument." >&2; print_help; exit 1 ;;
+    esac
+done
+
+info "Starting nf-flu Nanopore test execution script with ${CPU} CPU cores and ${MEMORY} memory..."
+
+FASTA_ZST_URL="https://api.figshare.com/v2/file/download/41415330"
+CSV_ZST_URL="https://api.figshare.com/v2/file/download/41415333"
+
+download_file() {
+    local url=$1
+    local output=$2
+
+    if [ ! -f "$output" ]; then
+        info "Downloading $output from $url..."
+        curl --silent -SLk "$url" -o "$output"
+        info "Downloaded $output."
+    else
+        info "$output already exists. Skipping download."
+    fi
+}
+
+create_samplesheet() {
+    local samplesheet=$1
+    echo "sample,reads" | tee "$samplesheet"
+    echo "ERR6359501-10k,$(realpath reads/ERR6359501-10k.fastq.gz)" | tee -a "$samplesheet"
+    echo "ERR6359501,$(realpath reads/run1)" | tee -a "$samplesheet"
+    echo "ERR6359501,$(realpath reads/run2)" | tee -a "$samplesheet"
+    echo "SRR24826962,$(realpath reads/SRR24826962.fastq.gz)" | tee -a "$samplesheet"
+    echo "ntc-bc15,$(realpath reads/ntc-bc15.fastq.gz)" | tee -a "$samplesheet"
+    echo "ntc-bc31,$(realpath reads/ntc-bc31.fastq.gz)" | tee -a "$samplesheet"
+    echo "ntc-bc47,$(realpath reads/ntc-bc47.fastq.gz)" | tee -a "$samplesheet"
+}
+
+FASTA_ZST_FILE="influenza.fna.zst"
+CSV_ZST_FILE="influenza.csv.zst"
+
+# Create directories
+mkdir -p reads/{run1,run2}
+
+# Download test data files
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/SRR24826962.sampled.fastq.gz" "reads/SRR24826962.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ERR6359501-10k.fastq.gz" "reads/ERR6359501-10k.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run1-s11-ERR6359501.fastq.gz" "reads/run1/s11-ERR6359501.fastq.gz"
+if [ ! -f "reads/run1/s1-ERR6359501.fastq" ]; then
+    download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run1-s1-ERR6359501.fastq.gz" "reads/run1/s1-ERR6359501.fastq.gz"
+    gunzip reads/run1/s1-ERR6359501.fastq.gz
+else
+    info "'reads/run1/s1-ERR6359501.fastq' already exists!"
+fi
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run2-s22-ERR6359501.fastq.gz" "reads/run2/s22-ERR6359501.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/run2-s2-ERR6359501.fastq.gz" "reads/run2/s2-ERR6359501.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc15.fastq.gz" "reads/ntc-bc15.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc31.fastq.gz" "reads/ntc-bc31.fastq.gz"
+download_file "https://github.com/CFIA-NCFAD/nf-test-datasets/raw/nf-flu/nanopore/fastq/ntc-bc47.fastq.gz" "reads/ntc-bc47.fastq.gz"
+
+info "Creating samplesheet.csv"
+create_samplesheet "samplesheet.csv"
+
+info "Download FASTA and CSV files"
+download_file "$FASTA_ZST_URL" "$FASTA_ZST_FILE"
+download_file "$CSV_ZST_URL" "$CSV_ZST_FILE"
+
+if [ -d "$WORKFLOW_PATH" ]; then
+ info "Running Nextflow pipeline from local path: $WORKFLOW_PATH"
+else
+ info "Pulling Nextflow pipeline from remote: $WORKFLOW_PATH"
+ nextflow pull "$WORKFLOW_PATH"
+fi
+
+nextflow run "$WORKFLOW_PATH" \
+    -profile test_nanopore,docker \
+    -resume \
+    --platform nanopore \
+    --input samplesheet.csv \
+    --ncbi_influenza_fasta $FASTA_ZST_FILE \
+    --ncbi_influenza_metadata $CSV_ZST_FILE \
+    --max_cpus $CPU --max_memory "$MEMORY"


### PR DESCRIPTION
Fix MultiQC report generation due to module filter paths not working like in v1.12.

### Software Updates

* multiqc: `1.21` -> `1.22.1`

### Changes

* test: add `tests/run-nanopore-test.sh` to conveniently run Nanopore test locally

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - ensure that you've added the version info to a `versions.yml` and added it to the `ch_versions` channel in the workflow you added the tool to.
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [ ] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
