### PR TITLE
Fix issue 84; no VADR seq name max length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This patch release fixes an issue ([#84](https://github.com/CFIA-NCFAD/nf-flu/issues/84)) with long sample names (over 50 characters) causing VADR to fail. `--noseqnamemax` has been added to the default arguments for VADR to avoid this issue.
 
+### Changes
+
+* **fix**: Added `--noseqnamemax` to VADR default arguments to avoid issues with long sample names causing VADR to fail.
+* **config**: Output directory paths for IRMA and Bcftools consensus VADR annotation results were made more explicit and clear for the Illumina workflow.
+
 ## [[3.5.0](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.5.0)] - 2024-10
 
 This release expands the Illumina workflow by adding BLAST analysis, coverage plots, variant calling, and MultiQC reports. Modifications were made to existing modules, and new modules were added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.5.1](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.5.1)] - 2024-10-08
+
+This patch release fixes an issue ([#84](https://github.com/CFIA-NCFAD/nf-flu/issues/84)) with long sample names (over 50 characters) causing VADR to fail. `--noseqnamemax` has been added to the default arguments for VADR to avoid this issue.
+
 ## [[3.5.0](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.5.0)] - 2024-10
 
 This release expands the Illumina workflow by adding BLAST analysis, coverage plots, variant calling, and MultiQC reports. Modifications were made to existing modules, and new modules were added.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -59,7 +59,7 @@ process {
     ]
   }
   withName: 'VADR' {
-    ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3'
+    ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3 --noseqnamemax'
     publishDir = [
       [
         path: { "${params.outdir}/annotation/vadr" },

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -173,33 +173,66 @@ process {
     ]
   }
 
-  withName: 'VADR_CONSENSUS' {
+  withName: 'VADR_IRMA' {
     ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3 --noseqnamemax'
     publishDir = [
       [
-        path: { "${params.outdir}/annotation/vadr/${sample}_cat_consensus" },  // Unique path for the new process
+        path: { "${params.outdir}/annotation/vadr/irma/${sample}" },  // Unique path for the new process
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
       ]
     ]
   }
 
-  withName: 'VADR_SUMMARIZE_ISSUES_CONSENSUS' {
-    ext.args = ''
+  withName: 'VADR_BCFTOOLS' {
+    ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3 --noseqnamemax'
     publishDir = [
       [
-        path: { "${params.outdir}/annotation/vadr_consensus_summary" },  // Ensure unique path
+        path: { "${params.outdir}/annotation/vadr/bctools/${sample}" },  // Unique path for the new process
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
       ]
     ]
   }
 
-  withName: 'POST_TABLE2ASN_CONSENSUS' {
+  withName: 'VADR_SUMMARIZE_ISSUES_IRMA' {
     ext.args = ''
     publishDir = [
       [
-        path: { "${params.outdir}/annotation/${sample}_cat_consensus" },  // Unique path for the post-table2asn process
+        path: { "${params.outdir}/annotation/irma" },  // Ensure unique path
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+      ]
+    ]
+  }
+
+  withName: 'VADR_SUMMARIZE_ISSUES_BCFTOOLS' {
+    ext.args = ''
+    publishDir = [
+      [
+        path: { "${params.outdir}/annotation/bcftools" },  // Ensure unique path
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+      ]
+    ]
+  }
+
+  withName: 'POST_TABLE2ASN_IRMA' {
+    ext.args = ''
+    publishDir = [
+      [
+        path: { "${params.outdir}/annotation/irma/${sample}" },  // Unique path for the post-table2asn process
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+      ]
+    ]
+  }
+
+  withName: 'POST_TABLE2ASN_BCFTOOLS' {
+    ext.args = ''
+    publishDir = [
+      [
+        path: { "${params.outdir}/annotation/bcftools/${sample}" },  // Unique path for the post-table2asn process
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
       ]

--- a/conf/modules_illumina.config
+++ b/conf/modules_illumina.config
@@ -174,7 +174,7 @@ process {
   }
 
   withName: 'VADR_CONSENSUS' {
-    ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3'
+    ext.args = '--mkey flu -r --atgonly --xnocomp --nomisc --alt_fail extrant5,extrant3 --noseqnamemax'
     publishDir = [
       [
         path: { "${params.outdir}/annotation/vadr/${sample}_cat_consensus" },  // Unique path for the new process

--- a/docs/output.md
+++ b/docs/output.md
@@ -254,9 +254,9 @@ Consensus sequences are annotated using [VADR][]. The output files are available
 <details markdown="1">
 <summary>Output files</summary>
 
-- `annotation/vadr/<sample>`
+- `annotation/vadr/<sample>`/`annotation/vadr/irma/<sample>`/`annotation/vadr/bcftools/<sample>`
   - Each sample will have its own VADR annotation analysis output directory. Feature table output can be found in the `*.vadr.pass.tbl` files.
-- `annotation/<sample>/`
+- `annotation/<sample>`/`annotation/vadr/irma/<sample>`/`annotation/vadr/bcftools/<sample>`
   - VADR Feature Table output is converted to Genbank, GFF and FASTA format for downstream analyses. FASTA files with nucleotide sequences of genetic features (CDS, mature peptide, signal peptide, etc) can be found in the `.ffn` files and amino acid sequences of genetic features can be found in the `.faa` files.
 - `annotation/vadr-annotation-failed-sequences.txt`: list of sequences that failed VADR annotation
 - `annotation/vadr-annotation-issues.txt`: table describing sequences that had issues with VADR annotation

--- a/nextflow.config
+++ b/nextflow.config
@@ -155,10 +155,10 @@ manifest {
   description     = 'Influenza A virus genome assembly pipeline'
   homePage        = 'https://github.com/CFIA-NCFAD/nf-flu'
   author          = 'Peter Kruczkiewicz, Hai Nguyen'
-  version         = '3.4.1'
+  version         = '3.5.1'
   nextflowVersion = '!>=22.10.1'
   mainScript      = 'main.nf'
-  doi             = '10.5281/zenodo.7011213'
+  doi             = '10.5281/zenodo.13892044'
 }
 
 // Following function from https://github.com/nf-core/vipr/blob/master/nextflow.config#L88


### PR DESCRIPTION
This PR fixes an issue ([#84](https://github.com/CFIA-NCFAD/nf-flu/issues/84)) with long sample names (over 50 characters) causing VADR to fail. `--noseqnamemax` has been added to the default arguments for VADR to avoid this issue.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - ensure that you've added the version info to a `versions.yml` and added it to the `ch_versions` channel in the workflow you added the tool to.
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CFIA-NCFAD/nf-flu/tree/master/.github/CONTRIBUTING.md)
  - [X] If necessary, also make a PR on [the CFIA-NCFAD/nf-test-datasets repo](https://github.com/CFIA-NCFAD/nf-test-datasets/pull/new)
- [ ] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
