### PR TITLE
Prepare Seqera platform bugfix patch release 3.10.1

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -151,7 +151,6 @@
                         "FLU-pacbio",
                         "FLU-ref",
                         "FLU-secondary",
-                        "FLU",
                         "FLU-avian-residual",
                         "FLU-fast",
                         "FLU-minion",


### PR DESCRIPTION
This pull request makes a small update to the nextflow_schema.json file by removing a duplicate"FLU" option from the [irma_module] ENUM. This fix is necessary in order to allow the pipeline to be launched using Seqera Platform.

- https://github.com/peterk87/nf-flu/pull/26

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Ensure the test suite passes (`nextflow run . -profile test_{illumina,nanopore},docker`).
- [X] Ensure that the [`nf-test`](https://github.com/askimed/nf-test) tests pass.
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
