### PR TITLE
fix: subtyping_report.py edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['25.04.0', '26.04.2']
+        nxf_ver: ['25.04.0', '26.04.3']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cache Nextflow binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-nextflow
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Cache nf-test
         id: cache-nf-test
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /usr/local/bin/nf-test
@@ -65,11 +65,27 @@ jobs:
       - name: Run nf-test
         run: |
           nf-test test
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: 'tests/requirements.txt'
+      - name: Install dependencies
+        run: uv pip install -r tests/requirements.txt
+      - name: Run pytest
+        run: uv run pytest tests/bin -v
   cacheroni:
     runs-on: ubuntu-latest
     steps:
       - name: Cache seqtk binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-seqtk
         with:
           path: /usr/local/bin/seqtk
@@ -83,7 +99,7 @@ jobs:
           make install
           which seqtk
       - name: Cache subsampled influenza.fna
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-influenza-fna
         with:
           path: influenza-10k.fna.zst
@@ -93,7 +109,7 @@ jobs:
         run: |
           curl --silent -SLk ${FASTA_ZST_URL} | zstdcat | seqtk sample -s 789 - 10000 | zstd -ck > influenza-10k.fna.zst
       - name: Cache influenza.csv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-influenza-csv
         with:
           path: influenza.csv.zst
@@ -103,7 +119,7 @@ jobs:
         run: |
           curl --silent -SLk ${CSV_ZST_URL} > influenza.csv.zst
       - name: Cache VADR flu model tar.gz
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-vadr-models
         with:
           path: vadr-models-flu-1.6.3-2.tar.gz
@@ -116,34 +132,34 @@ jobs:
     name: Run assemblies subworkflow test
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'CFIA-NCFAD/nf-flu') }}
     runs-on: ubuntu-latest
-    needs: [cacheroni, nftest]
+    needs: [cacheroni, nftest, pytest]
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
     strategy:
         matrix:
             # Nextflow versions: check pipeline minimum and current latest
-            nxf_ver: ['25.04.0', '26.04.2']
+            nxf_ver: ['25.04.0', '26.04.3']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: restore cached influenza-10k.fna.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza-10k.fna.zst
           key: influenza-fna
       - name: restore cached influenza.csv.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza.csv.zst
           key: influenza-csv
       - name: restore cached vadr-models-flu-1.6.3-2.tar.gz
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: vadr-models-flu-1.6.3-2.tar.gz
           key: vadr-models-tgz
       - name: Cache Nextflow binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-nextflow
         with:
           path: |
@@ -171,20 +187,20 @@ jobs:
             --max_memory "12 GB"
       - name: Upload .nextflow.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextflow-log-assemblies-${{ matrix.nxf_ver }}
           path: .nextflow.log
           include-hidden-files: true
       - name: Upload pipeline_info/
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: assemblies-test-results-pipline_info-${{ matrix.nxf_ver }}
           path: results/pipeline_info
       - name: Upload nf-flu-subtyping-report.xlsx
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: assemblies-test-results-subtyping-report-${{ matrix.nxf_ver }}
           path: results/nf-flu-subtyping-report.xlsx
@@ -194,34 +210,34 @@ jobs:
     # Only run on push if this is the nf-flu dev branch (merged PRs)
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'CFIA-NCFAD/nf-flu') }}
     runs-on: ubuntu-latest
-    needs: [cacheroni, nftest]
+    needs: [cacheroni, nftest, pytest]
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['25.04.0', '26.04.2']
+        nxf_ver: ['25.04.0', '26.04.3']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: restore cached seqtk binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /usr/local/bin/seqtk
           key: seqtk
       - name: restore cached influenza-10k.fna.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza-10k.fna.zst
           key: influenza-fna
       - name: restore cached influenza.csv.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza.csv.zst
           key: influenza-csv
       - name: restore cached vadr-models-flu-1.6.3-2.tar.gz
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: vadr-models-flu-1.6.3-2.tar.gz
           key: vadr-models-tgz
@@ -234,7 +250,7 @@ jobs:
           docker system df
           docker images
       - name: Cache Nextflow binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-nextflow
         with:
           path: |
@@ -265,20 +281,20 @@ jobs:
           docker images
       - name: Upload Artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: illumina-test-results-${{ matrix.nxf_ver }}
           path: results/pipeline_info
       - name: Upload .nextflow.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextflow-log-illumina-${{ matrix.nxf_ver }}
           path: .nextflow.log
           include-hidden-files: true
       - name: Upload multiqc_report.html
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: illumina-test-results-multiqc-${{ matrix.nxf_ver }}
           path: results/MultiQC/multiqc_report.html
@@ -288,34 +304,34 @@ jobs:
     # Only run on push if this is the nf-flu dev branch (merged PRs)
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'CFIA-NCFAD/nf-flu') }}
     runs-on: ubuntu-latest
-    needs: [cacheroni, nftest]
+    needs: [cacheroni, nftest, pytest]
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['25.04.0', '26.04.2']
+        nxf_ver: ['25.04.0', '26.04.3']
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: restore cached seqtk binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /usr/local/bin/seqtk
           key: seqtk
       - name: restore cached influenza-10k.fna.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza-10k.fna.zst
           key: influenza-fna
       - name: restore cached influenza.csv.zst
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: influenza.csv.zst
           key: influenza-csv
       - name: restore cached vadr-models-flu-1.6.3-2.tar.gz
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: vadr-models-flu-1.6.3-2.tar.gz
           key: vadr-models-tgz
@@ -328,7 +344,7 @@ jobs:
           docker system df
           docker images
       - name: Cache Nextflow binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-nextflow
         with:
           path: |
@@ -343,7 +359,7 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
       - name: Cache test sample reads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-reads
         with:
           path: reads/
@@ -397,26 +413,26 @@ jobs:
           docker images
       - name: Upload .nextflow.log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextflow-log-nanopore-${{ matrix.nxf_ver }}
           path: .nextflow.log
           include-hidden-files: true
       - name: Upload pipeline_info/
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nanopore-test-results-pipline_info-${{ matrix.nxf_ver }}
           path: results/pipeline_info
       - name: Upload nf-flu-subtyping-report.xlsx
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nanopore-test-results-subtyping-report-${{ matrix.nxf_ver }}
           path: results/nf-flu-subtyping-report.xlsx
       - name: Upload multiqc_report.html
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nanopore-test-results-multiqc-${{ matrix.nxf_ver }}
           path: results/MultiQC/multiqc_report.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           python-version: '3.12'
           enable-cache: true
           cache-dependency-glob: 'tests/requirements.txt'
+          activate-environment: true
+          no-project: true
       - name: Install dependencies
         run: uv pip install -r tests/requirements.txt
       - name: Run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,8 +11,8 @@ jobs:
   Markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ env/
 # Local scratch (not tests/ — project test suite)
 test/
 data/
+!tests/data/
+!tests/data/**
 
 # IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,54 @@
+# Nextflow
 .nextflow/
-.nextflow.log*
-results
+.nextflow*
+work/
+results/
 results*
-results/*
-work
-work/*
-.nextflow.log*
-test/
-.idea/
+
+# nf-test
 .nf-test/
-.nf-test.log
+.nf-test.log*
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg
+*.egg-info/
+.eggs/
+dist/
+build/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+*.cover
+.hypothesis/
+.tox/
+.nox/
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Local scratch (not tests/ — project test suite)
+test/
+data/
+
+# IDE
+.idea/
+.vscode/
+.cursor/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+* fix: `subtyping_report.py` edge cases when HA/NA segments are absent or IAV contamination skews genus detection (#134)
+* test: add nf-test for `subtyping_report.nf` covering missing HA/NA segments and IBV/IAV contamination (#134)
+* dev: add pytest job to CI (via uv) and `tests/requirements.txt` for bin script unit tests
+
 ## [[3.10.4](https://github.com/CFIA-NCFAD/nf-flu/releases/tag/3.10.4)] - 2026-05-27
 
 * Update: GenoFLU 1.06 -> 1.07, IRMA 1.0.2 -> 1.2.0

--- a/bin/subtyping_report.py
+++ b/bin/subtyping_report.py
@@ -15,7 +15,7 @@ import sys
 from collections import defaultdict
 from os import PathLike
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union, Any
+from typing import Any, Optional, Protocol, cast
 
 import typer
 import numpy as np
@@ -23,7 +23,7 @@ import pandas as pd
 import polars as pl
 from rich.logging import RichHandler
 
-VERSION = "2025.03.1"
+VERSION = "2026.06.1"
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +231,7 @@ def parse_blast_result(
         top: int = 3,
         pident_threshold: float = 0.85,
         min_aln_length: int = 50,
-) -> Optional[Tuple[pl.DataFrame, Dict, str]]:
+) -> tuple[pl.DataFrame, dict, str] | None:
     logger.info(f"Parsing BLAST results from {blast_result}")
 
     try:
@@ -312,25 +312,80 @@ def parse_blast_result(
     genus = top_genus(df_merge)
     if not get_top_ref:
         is_iav = genus == 'Alphainfluenzavirus'
-        H_results = None
-        N_results = None
-        if "4" in segments:
-            H_results = find_h_or_n_type(df_merge, "4", is_iav, min_pident=pident_threshold)
-            subtype_results_summary |= H_results
-        if "6" in segments:
-            N_results = find_h_or_n_type(df_merge, "6", is_iav, min_pident=pident_threshold)
-            subtype_results_summary.update(N_results)
+        H_results = find_h_or_n_type(df_merge, "4", is_iav, min_pident=pident_threshold)
+        subtype_results_summary |= H_results
+        N_results = find_h_or_n_type(df_merge, "6", is_iav, min_pident=pident_threshold)
+        subtype_results_summary.update(N_results)
         subtype_results_summary["Genotype"] = get_subtype_value(H_results, N_results, is_iav)
 
     return df_top_seg_matches, subtype_results_summary, genus
 
 
+class _PolarsGroupBy(Protocol):
+    """Subset of Polars group-by API used by ``top_genus``."""
+
+    def first(self) -> pl.DataFrame: ...
+
+    def agg(self, *args: object, **kwargs: object) -> pl.DataFrame: ...
+
+    def sort(self, *args: object, **kwargs: object) -> pl.DataFrame: ...
+
+
+def _polars_groupby(df: pl.DataFrame, *cols: str) -> _PolarsGroupBy:
+    """Select ``group_by`` or ``groupby`` depending on the installed Polars version.
+
+    The pipeline biocontainer pins Polars 0.17.9 (``DataFrame.groupby``). Local dev
+    and pytest use newer Polars, where the method was renamed to ``group_by``. We
+    cannot use ``getattr(df, "group_by", df.groupby)``: on new Polars, accessing
+    ``df.groupby`` raises. The ``Protocol`` return type keeps pyright happy across
+    both versions without importing version-specific ``GroupBy`` types.
+    """
+    if hasattr(df, "group_by"):
+        groupby_obj = getattr(df, "group_by")(*cols)
+    else:
+        groupby_obj = df.groupby(*cols)
+    return cast(_PolarsGroupBy, cast(object, groupby_obj))
+
+
 def top_genus(df: pl.DataFrame) -> str:
-    genus: pl.Series = df['Genus']
-    return genus.value_counts(sort=True)['Genus'][0]
+    """Determine genus by majority vote of top BLAST hit per segment.
+
+    Uses segment-level voting rather than total hit count to avoid one
+    contaminated segment with many hits overriding the true lineage.
+    """
+    df_with_genus = df.filter(pl.col("Genus").is_not_null())
+    if df_with_genus.shape[0] == 0:
+        return df['Genus'].value_counts(sort=True)['Genus'][0]
+
+    sorted_df = df_with_genus.sort(["sample_segment", "bitscore"], descending=[False, True])
+    top_per_segment = _polars_groupby(sorted_df, "sample_segment").first()
+    genus_votes = (
+        _polars_groupby(top_per_segment, "Genus")
+        .agg(
+            pl.count().alias("segment_count"),
+            pl.col("bitscore").sum().alias("bitscore_sum"),
+        )
+        .sort(["segment_count", "bitscore_sum"], descending=[True, True])
+    )
+    if genus_votes.shape[0] == 0:
+        return df_with_genus['Genus'].value_counts(sort=True)['Genus'][0]
+
+    top = genus_votes.to_dicts()[0]
+    logger.debug(
+        "Genus vote by segment: %s",
+        genus_votes.select(["Genus", "segment_count", "bitscore_sum"]).to_dicts(),
+    )
+    logger.info(
+        "Selected genus %s (%s/%s segments, bitscore sum=%s)",
+        top["Genus"],
+        top["segment_count"],
+        top_per_segment.shape[0],
+        top["bitscore_sum"],
+    )
+    return top["Genus"]
 
 
-def get_subtype_value(H_results: Optional[Dict], N_results: Optional[Dict], is_iav: bool) -> str:
+def get_subtype_value(H_results: dict | None, N_results: dict | None, is_iav: bool) -> str:
     subtype = ""
     if not is_iav:
         return "N/A"
@@ -361,7 +416,7 @@ def find_h_or_n_type(
         seg: str,
         is_iav: bool,
         min_pident: float = 0.85,
-) -> Dict[str, Union[str, int, float]]:
+) -> dict[str, str | int | float]:
     assert seg in {
         "4",
         "6",
@@ -457,7 +512,7 @@ def find_h_or_n_type(
             )
             break
 
-    top_result: Dict[str, Any] = list(df_segment.head(1).iter_rows(named=True))[0]
+    top_result: dict[str, Any] = list(df_segment.head(1).iter_rows(named=True))[0]
     db_prop_matches = top_type_count / total_count if is_iav and not isinstance(top_type_count, str) and not isinstance(total_count, str) else "N/A"
     results_summary = {
         f"{h_or_n}_type": top_type if is_iav else "N/A",
@@ -519,7 +574,7 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
-def get_segment_names(genus: str) -> Dict[int, str]:
+def get_segment_names(genus: str) -> dict[int, str]:
     segment_names = {}
     if genus == 'Alphainfluenzavirus':
         segment_names = IAV_SEGMENT_NAMES
@@ -559,7 +614,7 @@ def get_col_widths(df, index=False):
 
 
 def write_excel(
-        name_dfs: List[Tuple[str, pd.DataFrame]],
+        name_dfs: list[tuple[str, pd.DataFrame]],
         output_dest: PathLike,
         sheet_name_index: bool = True,
 ) -> None:
@@ -624,7 +679,7 @@ def find_matching_files(
         pattern: str,
         recursive: bool = True,
         ignore_case: bool = True,
-) -> List[Path]:
+) -> list[Path]:
     # Walk through the directory recursively, following symlinks
     matching_files = []
     for root, dirs, files in os.walk(directory, followlinks=True):
@@ -632,6 +687,10 @@ def find_matching_files(
             if file_name.endswith(pattern):
                 matching_files.append(Path(root) / file_name)
     return matching_files
+
+# Pipeline conda env pins typer=0.7, which does not support typing.Annotated for CLI
+# metadata; keep typer.Option defaults and silence pyright's default-initializer rule.
+# pyright: reportCallInDefaultInitializer=false
 
 @app.command()
 def report(
@@ -661,7 +720,7 @@ def report(
     if not blast_results:
         logger.error(f"No BLAST results files found in directory '{blast_results}'!")
         sys.exit(1)
-    ordered_samples: Optional[List[str]] = None
+    ordered_samples: list[str] | None = None
     if samplesheet:
         samplesheet_path = Path(samplesheet)
         if samplesheet_path.resolve().exists():
@@ -730,11 +789,8 @@ def report(
         df_subtype_results = pd.DataFrame(all_subtype_results).transpose()
         ordered_sample_to_idx = {sample: idx for idx, sample in enumerate(ordered_samples)} if ordered_samples else None
 
-        cols_concat = {}
-        for col in SUBTYPE_RESULTS_SUMMARY_COLUMNS + H_COLUMNS + N_COLUMNS:
-            if col in df_subtype_results.columns:
-                cols_concat[col] = ''
-        df_subtype_results = df_subtype_results[list(cols_concat.keys())]
+        all_cols = list(dict.fromkeys(SUBTYPE_RESULTS_SUMMARY_COLUMNS + H_COLUMNS + N_COLUMNS))
+        df_subtype_results = df_subtype_results.reindex(columns=all_cols, fill_value="N/A")
 
         if ordered_samples and ordered_sample_to_idx:
             df_subtype_results = df_subtype_results.sort_values(

--- a/tests/bin/test_subtyping_report.py
+++ b/tests/bin/test_subtyping_report.py
@@ -1,0 +1,124 @@
+import sys
+from pathlib import Path
+
+import polars as pl
+import pandas as pd
+
+# Polars >= 0.20 removed the enable_string_cache argument used by subtyping_report.py
+if hasattr(pl, "enable_string_cache"):
+    _orig_enable_string_cache = pl.enable_string_cache
+
+    def _enable_string_cache_compat(*args, **kwargs):
+        try:
+            return _orig_enable_string_cache(*args, **kwargs)
+        except TypeError:
+            return _orig_enable_string_cache()
+
+    pl.enable_string_cache = _enable_string_cache_compat
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "bin"))
+
+from subtyping_report import (  # noqa: E402
+    H_COLUMNS,
+    N_COLUMNS,
+    SUBTYPE_RESULTS_SUMMARY_COLUMNS,
+    find_h_or_n_type,
+    get_segment_names,
+    top_genus,
+)
+
+
+def _make_genus_df(rows: list[dict]) -> pl.DataFrame:
+    return pl.DataFrame(rows).with_columns(
+        pl.col("sample_segment").cast(pl.Categorical),
+        pl.col("Genus").cast(pl.Categorical),
+        pl.col("bitscore").cast(pl.Float32),
+    )
+
+
+def test_top_genus_ibv_with_iav_contamination():
+    rows = []
+    for seg in [1, 2, 5, 7, 8]:
+        rows.append(
+            {
+                "sample_segment": str(seg),
+                "Genus": "Betainfluenzavirus",
+                "bitscore": 100.0,
+            }
+        )
+    for _ in range(50):
+        rows.append(
+            {
+                "sample_segment": "3",
+                "Genus": "Alphainfluenzavirus",
+                "bitscore": 500.0,
+            }
+        )
+    assert top_genus(_make_genus_df(rows)) == "Betainfluenzavirus"
+
+
+def test_top_genus_pure_iav():
+    rows = [
+        {"sample_segment": str(seg), "Genus": "Alphainfluenzavirus", "bitscore": 200.0}
+        for seg in range(1, 9)
+    ]
+    assert top_genus(_make_genus_df(rows)) == "Alphainfluenzavirus"
+
+
+def test_find_h_or_n_type_returns_na_columns_when_segment_missing():
+    df_merge = pl.DataFrame(
+        {
+            "sample_segment": ["1"],
+            "Genotype": [""],
+            "qaccver": ["sample_1"],
+            "pident": [95.0],
+            "length": [500],
+            "mismatch": [0],
+            "gapopen": [0],
+            "bitscore": [400.0],
+            "qlen": [1500],
+            "#Accession": ["IBV001"],
+            "Host": ["Homo sapiens"],
+            "Geo_Location": ["Canada"],
+            "Collection_Date": ["2020"],
+            "slen": [1500],
+            "GenBank_Title": ["Influenza B virus segment 1"],
+        }
+    ).with_columns(pl.col("sample_segment").cast(pl.Categorical))
+
+    h_result = find_h_or_n_type(df_merge, "4", is_iav=False)
+    n_result = find_h_or_n_type(df_merge, "6", is_iav=False)
+
+    for key in H_COLUMNS:
+        if key in ("sample", "Genotype"):
+            continue
+        assert key in h_result
+        assert h_result[key] == "N/A"
+    for key in N_COLUMNS:
+        if key in ("sample", "Genotype"):
+            continue
+        assert key in n_result
+        assert n_result[key] == "N/A"
+
+
+def test_report_reindex_avoids_keyerror():
+    all_subtype_results = {
+        "sample_a": {
+            "sample": "sample_a",
+            "Genotype": "N/A",
+        }
+    }
+    all_cols = list(
+        dict.fromkeys(SUBTYPE_RESULTS_SUMMARY_COLUMNS + H_COLUMNS + N_COLUMNS)
+    )
+    df_subtype_results = pd.DataFrame(all_subtype_results).transpose()
+    df_subtype_results = df_subtype_results.reindex(columns=all_cols, fill_value="N/A")
+    df_subtype_predictions = df_subtype_results[SUBTYPE_RESULTS_SUMMARY_COLUMNS]
+    assert list(df_subtype_predictions.columns) == SUBTYPE_RESULTS_SUMMARY_COLUMNS
+
+
+def test_ibv_segment_names_after_contamination_genus_vote():
+    genus = "Betainfluenzavirus"
+    segment_names = get_segment_names(genus)
+    assert segment_names[1] == "1_PB1"
+    assert segment_names[2] == "2_PB2"

--- a/tests/data/subtyping_report/blastn_results/ibv_contaminated.blastn.txt
+++ b/tests/data/subtyping_report/blastn_results/ibv_contaminated.blastn.txt
@@ -1,0 +1,59 @@
+ibv_contaminated_1	IBV-SEG1	95.0	500	10	0	1	500	1	500	0.0	100.0	1500	1500	95.0	Influenza B virus segment 1
+ibv_contaminated_2	IBV-SEG2	95.0	500	10	0	1	500	1	500	0.0	100.0	1500	1500	95.0	Influenza B virus segment 2
+ibv_contaminated_5	IBV-SEG5	95.0	500	10	0	1	500	1	500	0.0	100.0	1500	1500	95.0	Influenza B virus segment 5
+ibv_contaminated_7	IBV-SEG7	95.0	500	10	0	1	500	1	500	0.0	100.0	1500	1500	95.0	Influenza B virus segment 7
+ibv_contaminated_8	IBV-SEG8	95.0	500	10	0	1	500	1	500	0.0	100.0	1500	1500	95.0	Influenza B virus segment 8
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3
+ibv_contaminated_3	IAV-SEG3	95.0	500	10	0	1	500	1	500	0.0	500.0	1500	1500	95.0	Influenza A virus (A/test/USA(H1N1)) segment 3

--- a/tests/data/subtyping_report/blastn_results/ibv_no_ha_na.blastn.txt
+++ b/tests/data/subtyping_report/blastn_results/ibv_no_ha_na.blastn.txt
@@ -1,0 +1,3 @@
+ibv_no_ha_na_1	IBV-SEG1	95.0	500	10	0	1	500	1	500	0.0	400.0	1500	1500	95.0	Influenza B virus segment 1
+ibv_no_ha_na_2	IBV-SEG2	95.0	500	10	0	1	500	1	500	0.0	390.0	1500	1500	95.0	Influenza B virus segment 2
+ibv_no_ha_na_5	IBV-SEG5	95.0	500	10	0	1	500	1	500	0.0	380.0	1500	1500	95.0	Influenza B virus segment 5

--- a/tests/data/subtyping_report/flu_metadata.csv
+++ b/tests/data/subtyping_report/flu_metadata.csv
@@ -1,0 +1,7 @@
+#Accession,Release_Date,Genus,Length,Genotype,Segment,Publications,Geo_Location,Host,Isolation_Source,Collection_Date,GenBank_Title
+IBV-SEG1,2020-01-01,Betainfluenzavirus,1500,,1,,Canada,Homo sapiens,,2020,Influenza B virus segment 1
+IBV-SEG2,2020-01-01,Betainfluenzavirus,1500,,2,,Canada,Homo sapiens,,2020,Influenza B virus segment 2
+IBV-SEG5,2020-01-01,Betainfluenzavirus,1500,,5,,Canada,Homo sapiens,,2020,Influenza B virus segment 5
+IBV-SEG7,2020-01-01,Betainfluenzavirus,1500,,7,,Canada,Homo sapiens,,2020,Influenza B virus segment 7
+IBV-SEG8,2020-01-01,Betainfluenzavirus,1500,,8,,Canada,Homo sapiens,,2020,Influenza B virus segment 8
+IAV-SEG3,2020-01-01,Alphainfluenzavirus,1500,H1N1,3,,USA,Homo sapiens,,2020,Influenza A virus (A/test/USA(H1N1)) segment 3

--- a/tests/modules/local/subtyping_report.nf.test
+++ b/tests/modules/local/subtyping_report.nf.test
@@ -1,0 +1,65 @@
+nextflow_process {
+  name "Test SUBTYPING_REPORT"
+  script "modules/local/subtyping_report.nf"
+  process "SUBTYPING_REPORT"
+  config "nextflow.config"
+
+  // input[2] uses vadr_outdirs/.gitkeep as a dummy placeholder so Nextflow stages an empty
+  // VADR directory; these tests do not require any .mdl files.
+
+  test("Should complete when HA and NA segments are absent") {
+    when {
+      process {
+        """
+        input[0] = file("$projectDir/tests/data/subtyping_report/flu_metadata.csv")
+        input[1] = file("$projectDir/tests/data/subtyping_report/blastn_results/ibv_no_ha_na.blastn.txt")
+        input[2] = file("$projectDir/tests/data/subtyping_report/vadr_outdirs/.gitkeep")
+        input[3] = []
+        """
+      }
+    }
+    then {
+      assertAll(
+        { assert process.success },
+        { assert process.trace.tasks().size() == 1 },
+        { assert snapshot(process.out.versions).match("versions_no_ha_na") },
+        {
+          assert snapshot(
+            path(process.out.report_dir.get(0) + "/subtype_predictions.csv"),
+            path(process.out.report_dir.get(0) + "/all_blast_results.csv"),
+            path(process.out.report_dir.get(0) + "/H_segment_results.csv"),
+            path(process.out.report_dir.get(0) + "/N_segment_results.csv"),
+          ).match("report_csvs_no_ha_na")
+        },
+      )
+    }
+  }
+
+  test("Should use IBV segment numbering when IAV contamination has more BLAST hits") {
+    when {
+      process {
+        """
+        input[0] = file("$projectDir/tests/data/subtyping_report/flu_metadata.csv")
+        input[1] = file("$projectDir/tests/data/subtyping_report/blastn_results/ibv_contaminated.blastn.txt")
+        input[2] = file("$projectDir/tests/data/subtyping_report/vadr_outdirs/.gitkeep")
+        input[3] = []
+        """
+      }
+    }
+    then {
+      assertAll(
+        { assert process.success },
+        { assert process.trace.tasks().size() == 1 },
+        { assert snapshot(process.out.versions).match("versions_contaminated") },
+        {
+          assert snapshot(
+            path(process.out.report_dir.get(0) + "/subtype_predictions.csv"),
+            path(process.out.report_dir.get(0) + "/all_blast_results.csv"),
+            path(process.out.report_dir.get(0) + "/H_segment_results.csv"),
+            path(process.out.report_dir.get(0) + "/N_segment_results.csv"),
+          ).match("report_csvs_contaminated")
+        },
+      )
+    }
+  }
+}

--- a/tests/modules/local/subtyping_report.nf.test.snap
+++ b/tests/modules/local/subtyping_report.nf.test.snap
@@ -1,0 +1,52 @@
+{
+    "report_csvs_no_ha_na": {
+        "content": [
+            "subtype_predictions.csv:md5,4139616184c6f62f238e00c498155e83",
+            "all_blast_results.csv:md5,e1c0835cc36c6ead5075bbcadad482db",
+            "H_segment_results.csv:md5,febb2711edce3752e41318d46ce6da9c",
+            "N_segment_results.csv:md5,49fc52e6d957b8df3622bcc2eaa0a91b"
+        ],
+        "timestamp": "2026-06-03T12:26:01.471151",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "report_csvs_contaminated": {
+        "content": [
+            "subtype_predictions.csv:md5,d2c171fc6ccc3d4b148dd3beff484834",
+            "all_blast_results.csv:md5,5549e7effe2ffaef86378ab2f30fc3c1",
+            "H_segment_results.csv:md5,090fdf0ee5bca32353ddf86756950586",
+            "N_segment_results.csv:md5,4b32eebf137a8393fe135248b34c3cb5"
+        ],
+        "timestamp": "2026-06-03T12:26:06.584411",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "versions_no_ha_na": {
+        "content": [
+            [
+                "versions.yml:md5,e8984a1953641ec191f258ed67705e30"
+            ]
+        ],
+        "timestamp": "2026-06-03T12:26:01.459113",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "versions_contaminated": {
+        "content": [
+            [
+                "versions.yml:md5,e8984a1953641ec191f258ed67705e30"
+            ]
+        ],
+        "timestamp": "2026-06-03T12:26:06.575291",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -3,3 +3,9 @@
     Nextflow config file for running tests
 ========================================================================================
 */
+
+process {
+  withName: 'SUBTYPING_REPORT' {
+    beforeScript = "export PATH=${projectDir}/bin:\$PATH"
+  }
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,6 @@
+pytest>=8.0
+numpy>=1.24
+pandas>=1.5
+polars>=0.17
+rich>=12.6
+typer>=0.7


### PR DESCRIPTION
This PR fixes #134 

* fix: `subtyping_report.py` edge cases when HA/NA segments are absent or IAV contamination skews genus detection (#134)
* test: add nf-test for `subtyping_report.nf` covering missing HA/NA segments and IBV/IAV contamination (#134)
* dev: add pytest job to CI (via uv) and `tests/requirements.txt` for bin script unit tests